### PR TITLE
fix: prevent dead-lock in climate control scheduling (v2.4.1)

### DIFF
--- a/climate-control.yaml
+++ b/climate-control.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Climate Control (Climate + Heater + Vent) with PV/Forecast, Logging & Push (v 2.4.0)
+  name: Climate Control (Climate + Heater + Vent) with PV/Forecast, Logging & Push (v 2.4.1)
   description: >
     Controls a climate entity and/or an external heater (switch/plug) based on
     inside/outside temperatures, prioritizes PV energy usage, optionally uses
@@ -413,8 +413,13 @@ trigger:
     id: scheduled
 
 condition:
-  - condition: time
-    after: !input datetime_helper
+  - condition: or
+    conditions:
+      - condition: trigger
+        id: scheduled
+      - condition: template
+        value_template: >-
+          {{ now().timestamp() >= as_timestamp(states(datetime_helper), 0) }}
 
 action:
   - variables:


### PR DESCRIPTION
Replace ambiguous `condition: time after: datetime_helper` with an `or` condition: the `scheduled` trigger always proceeds (the trigger itself guarantees correct timing), while `ha_start`/`reload` triggers use a full-datetime timestamp comparison to prevent running too early.

This eliminates the dead-lock where the time condition could fail at the exact scheduled boundary, leaving `datetime_helper` never updated and the automation stuck until HA restart.